### PR TITLE
Use promtail::version when downloading binary

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,7 +23,7 @@ class promtail::install {
 
   archive { "${binary_path}.gz":
     ensure        => present,
-    source        => "https://github.com/grafana/loki/releases/download/v0.3.0/${release_file_name}.gz",
+    source        => "https://github.com/grafana/loki/releases/download/${promtail::version}/${release_file_name}.gz",
     extract       => true,
     extract_path  => $version_dir,
     creates       => $binary_path,


### PR DESCRIPTION
Ran into some issues with unmatching checksums and it seems we were ignoring the version parameter.