### PR TITLE
Modify the type of archive depending on release version

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,13 +17,19 @@ class promtail::install {
   $version_dir = "${data_dir}/promtail-${promtail::version}"
   $binary_path = "${version_dir}/${release_file_name}"
 
+  if versioncmp($promtail::version, 'v1.0.0') > 0 {
+    $archive_type = 'zip'
+  } else {
+    $archive_type = 'gz'
+  }
+
   file { [$data_dir, $version_dir]:
     ensure => directory,
   }
 
   archive { "${binary_path}.gz":
     ensure        => present,
-    source        => "https://github.com/grafana/loki/releases/download/${promtail::version}/${release_file_name}.gz",
+    source        => "https://github.com/grafana/loki/releases/download/${promtail::version}/${release_file_name}.${archive_type}",
     extract       => true,
     extract_path  => $version_dir,
     creates       => $binary_path,


### PR DESCRIPTION
All versions before and including v1.0.0 are packaged in 'gz' archives, however, versions coming afterwards, such as v1.1.0 and further are packages in 'zip'.