### PR TITLE
Release file name changed from version v0.4.0

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,19 +9,24 @@ class promtail::install {
   case $facts['kernel'] {
     'Linux': {
       $data_dir = '/usr/local/promtail_data'
-      $release_file_name = 'promtail_linux_amd64'
     }
     default: { fail("${facts['kernel']} is not yet supported") }
   }
-
-  $version_dir = "${data_dir}/promtail-${promtail::version}"
-  $binary_path = "${version_dir}/${release_file_name}"
 
   if versioncmp($promtail::version, 'v1.0.0') > 0 {
     $archive_type = 'zip'
   } else {
     $archive_type = 'gz'
   }
+
+  if versioncmp($promtail::version, 'v0.3.0') > 0 {
+    $release_file_name = 'promtail-linux-amd64'
+  } else {
+    $release_file_name = 'promtail_linux_amd64'
+  }
+
+  $version_dir = "${data_dir}/promtail-${promtail::version}"
+  $binary_path = "${version_dir}/${release_file_name}"
 
   file { [$data_dir, $version_dir]:
     ensure => directory,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,11 @@ class promtail::install {
   case $facts['kernel'] {
     'Linux': {
       $data_dir = '/usr/local/promtail_data'
+      if versioncmp($promtail::version, 'v0.3.0') > 0 {
+        $release_file_name = 'promtail-linux-amd64'
+      } else {
+        $release_file_name = 'promtail_linux_amd64'
+      }
     }
     default: { fail("${facts['kernel']} is not yet supported") }
   }
@@ -17,12 +22,6 @@ class promtail::install {
     $archive_type = 'zip'
   } else {
     $archive_type = 'gz'
-  }
-
-  if versioncmp($promtail::version, 'v0.3.0') > 0 {
-    $release_file_name = 'promtail-linux-amd64'
-  } else {
-    $release_file_name = 'promtail_linux_amd64'
   }
 
   $version_dir = "${data_dir}/promtail-${promtail::version}"


### PR DESCRIPTION
All release file names contained underscores up to and including `v0.3.0`. From `v4.0.0` release file names use dashes.