### PR TITLE
prep for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.0](https://github.com/grafana/puppet-promtail/tree/1.0.0) (2020-11-02)
+
+[Full Changelog](https://github.com/grafana/puppet-promtail/compare/0.3.1...1.0.0)
+
+### Added
+
+- Enable service by default [\#22](https://github.com/grafana/puppet-promtail/pull/22) ([kubicgruenfeld](https://github.com/kubicgruenfeld))
+- bump default promtail version to v2.0.0 [\#20](https://github.com/grafana/puppet-promtail/pull/20) ([kubicgruenfeld](https://github.com/kubicgruenfeld))
+- allow custom source-url [\#19](https://github.com/grafana/puppet-promtail/pull/19) ([kubicgruenfeld](https://github.com/kubicgruenfeld))
+
 ## [0.3.1](https://github.com/grafana/puppet-promtail/tree/0.3.1) (2020-01-13)
 
 [Full Changelog](https://github.com/grafana/puppet-promtail/compare/0.3.0...0.3.1)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-promtail",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "author": "grafana",
   "summary": "Deploy and configure Grafana's Promtail",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR preps the repository for doing a 1.0.0 release. The module is plenty stable and has been being used in production for quite some time now so I see no reason to keep it pre v1 any longer.