### PR TITLE
Drop EoL Puppet, update supported OSs, fix example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         puppet_versions:
-          - '5'
           - '6'
+          # - '7' # PDK doesn't support Puppet 7 directly as of 1.18.1
 
     name: Puppet ${{ matrix.puppet_versions }}
     steps:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,11 +63,19 @@
 # @example
 #   include promtail
 #
-# @example
+# @example Sample of defining within a profile
 #   class { 'promtail':
-#     config_hash           => $config_hash,
-#     password_file_path    => '/etc/promtail/.gc_pw',
-#     password_file_content => Sensitive('myPassword'),
+#     clients_config_hash   => $clients_config_hash,
+#     positions_config_hash => $positions_config_hash,
+#     scrape_configs_hash   => $_real_scrape_configs_hash,
+#     password_file_content => $sensitive_password_file_content,
+#     password_file_path    => $password_file_path,
+#     service_ensure        => $service_ensure,
+#     server_config_hash    => $server_config_hash,
+#     target_config_hash    => $target_config_hash,
+#     bin_dir               => $bin_dir,
+#     checksum              => $checksum,
+#     version               => $version,
 #   }
 #
 # @example Settings in a Hiera file
@@ -89,22 +97,22 @@
 #       filename: /tmp/positions.yaml
 #   promtail::scrape_configs_hash:
 #     scrape_configs:
-#       - job_name: system_secure
-#         static_configs:
-#         - targets:
-#             - localhost
+#       - job_name: journal
+#         journal:
+#           max_age: 12h
 #           labels:
-#             job: var_log_secure
+#             job: systemd-journal
 #             host: "%{facts.networking.fqdn}"
-#             __path__: /var/log/secure
-#       - job_name: system_messages
-#         static_configs:
-#         - targets:
-#             - localhost
-#           labels:
-#             job: var_log_messages
-#             host: "%{facts.networking.fqdn}"
-#             __path__: /var/log/messages
+#         relabel_configs:
+#           - source_labels:
+#               - '__journal__systemd_unit'
+#             target_label: 'unit'
+#           - source_labels:
+#               - 'unit'
+#             regex: "session-(.*)"
+#             action: replace
+#             replacement: 'pam-session'
+#             target_label: 'unit'
 #
 # @example Merging scrape configs in Hiera
 #   class profile::logging::promtail {

--- a/metadata.json
+++ b/metadata.json
@@ -29,18 +29,21 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+        "7",
         "8"
       ]
     },
@@ -53,7 +56,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -66,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.18.1",


### PR DESCRIPTION
This makes the list of supported Puppet versions match the ones currently supported by Puppet, Inc. It also tunes the list of supported operating systems a bit and fixes an example that had bad info.

Fixes #25