### PR TITLE
Add support for newer dependencies versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.1.1 < 4.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "puppet/archive",

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.1.1 < 3.0.0"
+      "version_requirement": ">= 1.1.1 < 4.0.0"
     },
     {
       "name": "puppet/archive",

--- a/metadata.json
+++ b/metadata.json
@@ -14,15 +14,15 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 4.2.0 < 5.0.0"
+      "version_requirement": ">= 4.2.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Hello,

I added support for latest version of all dependencies, each major is about dropping support of Puppet 4 or/and Puppet 5 (which are already not supported by puppet-promtail).
See :

- camptocamp/systemd (also drops support of daemon-reload not used here) => [CHANGELOG 3.0.0](https://forge.puppet.com/modules/camptocamp/systemd/changelog#300-2021-04-16)
- puppet/archive (also drops support for CentOS 6, already not supported here) => [CHANGELOG 5.0.0](https://forge.puppet.com/modules/puppet/archive/changelog#v500-2021-04-16)
- puppetlabs/concat => [CHANGELOG 7.0.0](https://forge.puppet.com/modules/puppetlabs/concat/changelog#v700-2021-03-01)
- puppetlabs/stdlib => [CHANGELOG 7.0.0](https://forge.puppet.com/modules/puppetlabs/stdlib/changelog#v700-2021-03-01)

Let me know if something is wrong