### PR TITLE
Update github_changelog_generator to >= 1.16.4

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -9,7 +9,7 @@ Gemfile:
   required:
     ':development':
       - gem: 'github_changelog_generator'
-        version: '~> 1.15'
+        version: "~> 1.16', '>= 1.16.4"
       - gem: 'puppet-lint-absolute_classname-check'
         version: '~> 3.0'
       - gem: 'puppet-lint-absolute_template_path'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',                 require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',               require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "github_changelog_generator", '~> 1.15',                               require: false
+  gem "github_changelog_generator", '~> 1.16', '>= 1.16.4',                  require: false
   gem "puppet-lint-absolute_classname-check", '~> 3.0',                      require: false
   gem "puppet-lint-absolute_template_path", '~> 1.0',                        require: false
   gem "puppet-lint-anchor-check", '~> 1.0',                                  require: false


### PR DESCRIPTION
There were changes to the output between 1.15.0 and 1.16.4 so this will ensure that all users are pulling at least 1.16.4.